### PR TITLE
Deps: parent POM 55, wrapper 3.3.4, and modernization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Verify
-    uses: maveniverse/parent/.github/workflows/ci.yml@release-51
+    uses: maveniverse/parent/.github/workflows/ci.yml@release-55
     with:
       jdk-matrix: '[ "17", "21", "25" ]'
       maven-matrix: '[ "4.0.0-rc-5" ]'

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,19 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-wrapperVersion=3.3.2
+wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-4/apache-maven-4.0.0-rc-4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-5/apache-maven-4.0.0-rc-5-bin.zip

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-5/apache-maven-4.0.0-rc-5-bin.zip
+distributionSha256Sum=966874253b2491c49240eafca01a04dd0d72c96de96e7bdc726248be4e9c33a7

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -22,7 +22,7 @@
   <description>Mason Maven Extension.</description>
 
   <properties>
-    <version.jackson>2.21.1</version.jackson>
+    <version.jackson>2.21.3</version.jackson>
   </properties>
 
   <dependencies>
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>6.0.3</version>
+      <version>6.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>com.typesafe</groupId>
       <artifactId>config</artifactId>
-      <version>1.4.6</version>
+      <version>1.4.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -109,7 +109,7 @@
       <plugin>
         <groupId>org.codehaus.modello</groupId>
         <artifactId>modello-maven-plugin</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <executions>
           <execution>
             <id>generate-jackson-reader</id>

--- a/extension/src/main/java/eu/maveniverse/maven/mason/JsonReaderHelper.java
+++ b/extension/src/main/java/eu/maveniverse/maven/mason/JsonReaderHelper.java
@@ -208,7 +208,7 @@ public class JsonReaderHelper {
 
         JsonToken token = parser.nextToken();
         if (token == JsonToken.VALUE_NULL) {
-            return new XmlNodeImpl(name, null, attributes, children, location);
+            return XmlNode.newInstance(name, null, attributes, children, location);
         }
 
         while (token != JsonToken.END_OBJECT && token != null) {
@@ -246,7 +246,7 @@ public class JsonReaderHelper {
                                             }
                                         }
                                         parser.nextToken(); // Skip the outer object's END_OBJECT
-                                        arrayChildren.add(new XmlNodeImpl(
+                                        arrayChildren.add(XmlNode.newInstance(
                                                 singularName,
                                                 null,
                                                 new LinkedHashMap<>(),
@@ -260,7 +260,7 @@ public class JsonReaderHelper {
                                     while (token == JsonToken.FIELD_NAME) {
                                         String objFieldName = parser.currentName();
                                         token = parser.nextToken();
-                                        objectChildren.add(new XmlNodeImpl(
+                                        objectChildren.add(XmlNode.newInstance(
                                                 objFieldName,
                                                 parser.getText(),
                                                 new LinkedHashMap<>(),
@@ -268,7 +268,7 @@ public class JsonReaderHelper {
                                                 createLocation(parser, inputSrc, addLocationInformation)));
                                         token = parser.nextToken();
                                     }
-                                    arrayChildren.add(new XmlNodeImpl(
+                                    arrayChildren.add(XmlNode.newInstance(
                                             singularName,
                                             null,
                                             new LinkedHashMap<>(),
@@ -277,7 +277,7 @@ public class JsonReaderHelper {
                                 }
                             }
                         } else if (token.isScalarValue()) {
-                            arrayChildren.add(new XmlNodeImpl(
+                            arrayChildren.add(XmlNode.newInstance(
                                     singularName,
                                     parser.getText(),
                                     new LinkedHashMap<>(),
@@ -285,7 +285,7 @@ public class JsonReaderHelper {
                                     createLocation(parser, inputSrc, addLocationInformation)));
                         }
                     }
-                    children.add(new XmlNodeImpl(
+                    children.add(XmlNode.newInstance(
                             fieldName,
                             null,
                             new LinkedHashMap<>(),
@@ -295,7 +295,7 @@ public class JsonReaderHelper {
                     if (fieldName.startsWith("@")) {
                         attributes.put(fieldName.substring(1), parser.getText());
                     } else {
-                        children.add(new XmlNodeImpl(
+                        children.add(XmlNode.newInstance(
                                 fieldName,
                                 parser.getText(),
                                 new LinkedHashMap<>(),
@@ -309,6 +309,6 @@ public class JsonReaderHelper {
             token = parser.nextToken();
         }
 
-        return new XmlNodeImpl(name, value, attributes, children, location);
+        return XmlNode.newInstance(name, value, attributes, children, location);
     }
 }

--- a/extension/src/main/java/eu/maveniverse/maven/mason/JsonReaderHelper.java
+++ b/extension/src/main/java/eu/maveniverse/maven/mason/JsonReaderHelper.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import org.apache.maven.api.model.InputLocation;
 import org.apache.maven.api.model.InputSource;
 import org.apache.maven.api.xml.XmlNode;
-import org.apache.maven.internal.xml.XmlNodeImpl;
 
 /**
  * Helper methods for JSON/YAML parsing in Maven model readers.
@@ -237,7 +236,7 @@ public class JsonReaderHelper {
                                             if (token == JsonToken.FIELD_NAME) {
                                                 String objFieldName = parser.currentName();
                                                 token = parser.nextToken();
-                                                objectChildren.add(new XmlNodeImpl(
+                                                objectChildren.add(XmlNode.newInstance(
                                                         objFieldName,
                                                         parser.getText(),
                                                         new LinkedHashMap<>(),

--- a/extension/src/test/java/eu/maveniverse/maven/mason/MasonParserTest.java
+++ b/extension/src/test/java/eu/maveniverse/maven/mason/MasonParserTest.java
@@ -17,7 +17,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.Map;
 import javax.xml.stream.XMLStreamException;
 import org.apache.maven.api.model.Model;
@@ -33,7 +32,7 @@ class MasonParserTest {
 
     private MasonParser parser;
     private Model referenceModel;
-    private static final Map<String, Object> OPTIONS = Collections.emptyMap();
+    private static final Map<String, Object> OPTIONS = Map.of();
 
     @BeforeEach
     void setUp() throws Exception {

--- a/extension/src/test/java/eu/maveniverse/maven/mason/YamlParserTest.java
+++ b/extension/src/test/java/eu/maveniverse/maven/mason/YamlParserTest.java
@@ -31,7 +31,7 @@ import org.apache.maven.api.model.Prerequisites;
 import org.apache.maven.api.model.ReportPlugin;
 import org.apache.maven.api.model.Reporting;
 import org.apache.maven.api.services.Sources;
-import org.apache.maven.internal.xml.XmlNodeImpl;
+import org.apache.maven.api.xml.XmlNode;
 import org.apache.maven.model.v4.MavenStaxWriter;
 import org.junit.jupiter.api.Test;
 
@@ -84,35 +84,35 @@ class YamlParserTest {
                                                 .groupId("org.apache.maven.plugins")
                                                 .artifactId("maven-checkstyle-plugin")
                                                 .version("3.3.0")
-                                                .configuration(new XmlNodeImpl(
+                                                .configuration(XmlNode.newInstance(
                                                         "configuration",
                                                         null,
                                                         null,
                                                         List.of(
-                                                                new XmlNodeImpl("source", "17", null, null, null),
-                                                                new XmlNodeImpl("target", "17", null, null, null)),
+                                                                XmlNode.newInstance("source", "17", null, null, null),
+                                                                XmlNode.newInstance("target", "17", null, null, null)),
                                                         null))
                                                 .build(),
                                         Plugin.newBuilder()
                                                 .groupId("org.apache.maven.plugins")
                                                 .artifactId("maven-site-plugin")
                                                 .version("3.12.1")
-                                                .configuration(new XmlNodeImpl(
+                                                .configuration(XmlNode.newInstance(
                                                         "configuration",
                                                         null,
                                                         null,
-                                                        List.of(new XmlNodeImpl("locales", "en", null, null, null)),
+                                                        List.of(XmlNode.newInstance("locales", "en", null, null, null)),
                                                         null))
                                                 .build(),
                                         Plugin.newBuilder()
                                                 .groupId("org.apache.maven.plugins")
                                                 .artifactId("maven-deploy-plugin")
                                                 .version("3.1.1")
-                                                .configuration(new XmlNodeImpl(
+                                                .configuration(XmlNode.newInstance(
                                                         "configuration",
                                                         null,
                                                         null,
-                                                        List.of(new XmlNodeImpl("skip", "false", null, null, null)),
+                                                        List.of(XmlNode.newInstance("skip", "false", null, null, null)),
                                                         null))
                                                 .build(),
                                         Plugin.newBuilder()
@@ -147,34 +147,34 @@ class YamlParserTest {
                                         .groupId("org.apache.maven.plugins")
                                         .artifactId("maven-checkstyle-plugin")
                                         .version("3.3.0")
-                                        .configuration(new XmlNodeImpl(
+                                        .configuration(XmlNode.newInstance(
                                                 "configuration",
                                                 null,
                                                 null,
                                                 List.of(
-                                                        new XmlNodeImpl("source", "17", null, null, null),
-                                                        new XmlNodeImpl("target", "17", null, null, null)),
+                                                        XmlNode.newInstance("source", "17", null, null, null),
+                                                        XmlNode.newInstance("target", "17", null, null, null)),
                                                 null))
                                         .build(),
                                 Plugin.newBuilder()
                                         .groupId("org.apache.maven.plugins")
                                         .artifactId("maven-site-plugin")
                                         .version("3.12.1")
-                                        .configuration(new XmlNodeImpl(
+                                        .configuration(XmlNode.newInstance(
                                                 "configuration",
                                                 null,
                                                 null,
-                                                List.of(new XmlNodeImpl("locales", "en", null, null, null)),
+                                                List.of(XmlNode.newInstance("locales", "en", null, null, null)),
                                                 null))
                                         .build(),
                                 Plugin.newBuilder()
                                         .groupId("org.apache.maven.plugins")
                                         .artifactId("maven-deploy-plugin")
-                                        .configuration(new XmlNodeImpl(
+                                        .configuration(XmlNode.newInstance(
                                                 "configuration",
                                                 null,
                                                 null,
-                                                List.of(new XmlNodeImpl("skip", "false", null, null, null)),
+                                                List.of(XmlNode.newInstance("skip", "false", null, null, null)),
                                                 null))
                                         .build(),
                                 Plugin.newBuilder()
@@ -287,11 +287,11 @@ class YamlParserTest {
                                 .groupId("org.apache.maven.plugins")
                                 .artifactId("maven-surefire-report-plugin")
                                 .version("3.1.2")
-                                .configuration(new XmlNodeImpl(
+                                .configuration(XmlNode.newInstance(
                                         "configuration",
                                         null,
                                         null,
-                                        List.of(new XmlNodeImpl("showSuccess", "true", null, null, null)),
+                                        List.of(XmlNode.newInstance("showSuccess", "true", null, null, null)),
                                         null))
                                 .build()))
                         .build())

--- a/extension/src/test/java/eu/maveniverse/maven/mason/hocon/HoconLexerTest.java
+++ b/extension/src/test/java/eu/maveniverse/maven/mason/hocon/HoconLexerTest.java
@@ -441,9 +441,8 @@ class HoconLexerTest {
 
             assertTrue(
                     exception.getMessage().contains(expectedError),
-                    String.format(
-                            "Expected error message containing '%s' but got: %s",
-                            expectedError, exception.getMessage()));
+                    "Expected error message containing '%s' but got: %s"
+                            .formatted(expectedError, exception.getMessage()));
 
             assertTrue(
                     exception.getMessage().contains("try enclosing the key or value in double quotes"),

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.2
+# Apache Maven Wrapper startup batch script, version 3.3.4
 #
 # Optional ENV vars
 # -----------------
@@ -105,14 +105,17 @@ trim() {
   printf "%s" "${1}" | tr -d '[:space:]'
 }
 
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
 # parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
   case "${key-}" in
   distributionUrl) distributionUrl=$(trim "${value-}") ;;
   distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
   esac
-done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
-[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
 
 case "${distributionUrl##*/}" in
 maven-mvnd-*bin.*)
@@ -130,7 +133,7 @@ maven-mvnd-*bin.*)
   distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
   ;;
 maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
-*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
 esac
 
 # apply MVNW_REPOURL and calculate MAVEN_HOME
@@ -227,7 +230,7 @@ if [ -n "${distributionSha256Sum-}" ]; then
     echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
   elif command -v sha256sum >/dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
   elif command -v shasum >/dev/null; then
@@ -252,8 +255,41 @@ if command -v unzip >/dev/null; then
 else
   tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
 fi
-printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
-mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
 
 clean || :
 exec_maven "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eu.maveniverse.maven.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>51</version>
+    <version>55</version>
   </parent>
   <groupId>eu.maveniverse.maven.mason</groupId>
   <artifactId>mason-parent</artifactId>


### PR DESCRIPTION
## Changes

* Parent POM 51 → 55
* Maven wrapper 3.3.2 → 3.3.4, Maven 4.0.0-rc-4 → rc-5
* Add SHA-256 checksum for wrapper distribution integrity validation
* Jackson 2.21.1 → 2.21.3
* JUnit Jupiter 6.0.3 → 6.1.0
* Typesafe Config 1.4.6 → 1.4.8
* Modello plugin 2.6.0 → 2.7.0
* Migrate `XmlNodeImpl` constructor → `XmlNode.newInstance()` factory method
* `Collections.emptyMap()` → `Map.of()`
* `String.format()` → `.formatted()`