### PR TITLE
Fix @attribute prefix ignored in array elements

### DIFF
--- a/extension/src/main/java/eu/maveniverse/maven/mason/JsonReaderHelper.java
+++ b/extension/src/main/java/eu/maveniverse/maven/mason/JsonReaderHelper.java
@@ -231,46 +231,56 @@ public class JsonReaderHelper {
                                     // Skip the wrapper field, use its contents directly
                                     token = parser.nextToken(); // Move to the start of inner object
                                     if (token == JsonToken.START_OBJECT) {
+                                        Map<String, String> objAttributes = new LinkedHashMap<>();
                                         List<XmlNode> objectChildren = new ArrayList<>();
                                         while ((token = parser.nextToken()) != JsonToken.END_OBJECT) {
                                             if (token == JsonToken.FIELD_NAME) {
                                                 String objFieldName = parser.currentName();
                                                 token = parser.nextToken();
-                                                objectChildren.add(XmlNode.newInstance(
-                                                        objFieldName,
-                                                        parser.getText(),
-                                                        new LinkedHashMap<>(),
-                                                        new ArrayList<>(),
-                                                        createLocation(parser, inputSrc, addLocationInformation)));
+                                                if (objFieldName.startsWith("@")) {
+                                                    objAttributes.put(objFieldName.substring(1), parser.getText());
+                                                } else {
+                                                    objectChildren.add(XmlNode.newInstance(
+                                                            objFieldName,
+                                                            parser.getText(),
+                                                            new LinkedHashMap<>(),
+                                                            new ArrayList<>(),
+                                                            createLocation(parser, inputSrc, addLocationInformation)));
+                                                }
                                             }
                                         }
                                         parser.nextToken(); // Skip the outer object's END_OBJECT
                                         arrayChildren.add(XmlNode.newInstance(
                                                 singularName,
                                                 null,
-                                                new LinkedHashMap<>(),
+                                                objAttributes,
                                                 objectChildren,
                                                 createLocation(parser, inputSrc, addLocationInformation)));
                                     }
                                 } else {
                                     // Regular object, process its fields
+                                    Map<String, String> objAttributes = new LinkedHashMap<>();
                                     List<XmlNode> objectChildren = new ArrayList<>();
                                     parser.currentName(); // Reset to first field
                                     while (token == JsonToken.FIELD_NAME) {
                                         String objFieldName = parser.currentName();
                                         token = parser.nextToken();
-                                        objectChildren.add(XmlNode.newInstance(
-                                                objFieldName,
-                                                parser.getText(),
-                                                new LinkedHashMap<>(),
-                                                new ArrayList<>(),
-                                                createLocation(parser, inputSrc, addLocationInformation)));
+                                        if (objFieldName.startsWith("@")) {
+                                            objAttributes.put(objFieldName.substring(1), parser.getText());
+                                        } else {
+                                            objectChildren.add(XmlNode.newInstance(
+                                                    objFieldName,
+                                                    parser.getText(),
+                                                    new LinkedHashMap<>(),
+                                                    new ArrayList<>(),
+                                                    createLocation(parser, inputSrc, addLocationInformation)));
+                                        }
                                         token = parser.nextToken();
                                     }
                                     arrayChildren.add(XmlNode.newInstance(
                                             singularName,
                                             null,
-                                            new LinkedHashMap<>(),
+                                            objAttributes,
                                             objectChildren,
                                             createLocation(parser, inputSrc, addLocationInformation)));
                                 }

--- a/extension/src/test/java/eu/maveniverse/maven/mason/YamlParserTest.java
+++ b/extension/src/test/java/eu/maveniverse/maven/mason/YamlParserTest.java
@@ -188,6 +188,60 @@ class YamlParserTest {
     }
 
     @Test
+    void testBuildPluginConfigAttributes() throws Exception {
+        Model actual = loadAndParse("build-plugin-config-attributes.yaml");
+        Model expected = Model.newBuilder()
+                .modelVersion("4.0.0")
+                .groupId("org.apache.maven.extensions")
+                .artifactId("maven-yaml-extension")
+                .version("1.0.0-SNAPSHOT")
+                .name("Maven YAML Extension")
+                .build(Build.newBuilder()
+                        .plugins(List.of(Plugin.newBuilder()
+                                .groupId("org.apache.maven.plugins")
+                                .artifactId("maven-shade-plugin")
+                                .version("3.5.0")
+                                .configuration(XmlNode.newInstance(
+                                        "configuration",
+                                        null,
+                                        null,
+                                        List.of(XmlNode.newInstance(
+                                                "transformers",
+                                                null,
+                                                null,
+                                                List.of(
+                                                        XmlNode.newInstance(
+                                                                "transformer",
+                                                                null,
+                                                                Map.of(
+                                                                        "implementation",
+                                                                        "org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"),
+                                                                List.of(
+                                                                        XmlNode.newInstance(
+                                                                                "mainClass",
+                                                                                "com.example.Main",
+                                                                                null,
+                                                                                null,
+                                                                                null)),
+                                                                null),
+                                                        XmlNode.newInstance(
+                                                                "transformer",
+                                                                null,
+                                                                Map.of(
+                                                                        "implementation",
+                                                                        "org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"),
+                                                                null,
+                                                                null)),
+                                                null)),
+                                        null))
+                                .build()))
+                        .build())
+                .build();
+
+        assertModelEquals(expected, actual);
+    }
+
+    @Test
     void testBuildExtensions() throws Exception {
         Model actual = loadAndParse("build-extensions.yaml");
         Model expected = Model.newBuilder()

--- a/extension/src/test/resources/yaml/build-plugin-config-attributes.yaml
+++ b/extension/src/test/resources/yaml/build-plugin-config-attributes.yaml
@@ -1,0 +1,23 @@
+##
+## Copyright (c) 2025 Guillaume Nodet
+##
+## This program and the accompanying materials are made available under
+## the terms of the Eclipse Public License 2.0 which accompanies this
+## distribution and is available at:
+## https://www.eclipse.org/legal/epl-2.0/
+##
+## SPDX-License-Identifier: EPL-2.0
+##
+modelVersion: 4.0.0
+groupId: org.apache.maven.extensions
+artifactId: maven-yaml-extension
+version: 1.0.0-SNAPSHOT
+name: Maven YAML Extension
+build:
+  plugins:
+  - id: org.apache.maven.plugins:maven-shade-plugin:3.5.0
+    configuration:
+      transformers:
+        - "@implementation": org.apache.maven.plugins.shade.resource.ManifestResourceTransformer
+          mainClass: com.example.Main
+        - "@implementation": org.apache.maven.plugins.shade.resource.ServicesResourceTransformer


### PR DESCRIPTION
_Claude Code on behalf of Guillaume Nodet_

## Summary

- Fix the `@` prefix for XML attributes being ignored when processing objects inside arrays in `buildXmlNode`
- Two code paths in `JsonReaderHelper` (wrapper objects and regular objects within arrays) created child elements for all fields without checking for the `@` prefix — only the top-level code path handled it correctly
- Add test case for the shade plugin `transformers` use case from the issue

## Example

This YAML configuration now correctly produces `<transformer implementation="...">` instead of `<transformer><@implementation>...</@implementation></transformer>`:

```yaml
configuration:
  transformers:
    - "@implementation": org.apache.maven.plugins.shade.resource.ManifestResourceTransformer
      mainClass: com.example.Main
```

> **Note:** In YAML, `@` is a reserved indicator, so keys starting with `@` must be quoted.

## Test plan

- [x] New test `testBuildPluginConfigAttributes` verifies shade plugin transformer configuration with `@implementation` attributes
- [x] All 77 existing tests pass

Fixes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced YAML configuration parser to support XML attributes in plugin configurations.

* **Tests**
  * Added test coverage for plugin configuration attributes in Maven build scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->