### PR TITLE
Add test for @attribute in wrapper-object array form

### DIFF
--- a/extension/src/test/java/eu/maveniverse/maven/mason/YamlParserTest.java
+++ b/extension/src/test/java/eu/maveniverse/maven/mason/YamlParserTest.java
@@ -242,6 +242,51 @@ class YamlParserTest {
     }
 
     @Test
+    void testBuildPluginConfigAttributesWrapper() throws Exception {
+        Model actual = loadAndParse("build-plugin-config-attributes-wrapper.yaml");
+        Model expected = Model.newBuilder()
+                .modelVersion("4.0.0")
+                .groupId("org.apache.maven.extensions")
+                .artifactId("maven-yaml-extension")
+                .version("1.0.0-SNAPSHOT")
+                .name("Maven YAML Extension")
+                .build(Build.newBuilder()
+                        .plugins(List.of(Plugin.newBuilder()
+                                .groupId("org.apache.maven.plugins")
+                                .artifactId("maven-shade-plugin")
+                                .version("3.5.0")
+                                .configuration(XmlNode.newInstance(
+                                        "configuration",
+                                        null,
+                                        null,
+                                        List.of(XmlNode.newInstance(
+                                                "transformers",
+                                                null,
+                                                null,
+                                                List.of(XmlNode.newInstance(
+                                                        "transformer",
+                                                        null,
+                                                        Map.of(
+                                                                "implementation",
+                                                                "org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"),
+                                                        List.of(
+                                                                XmlNode.newInstance(
+                                                                        "mainClass",
+                                                                        "com.example.Main",
+                                                                        null,
+                                                                        null,
+                                                                        null)),
+                                                        null)),
+                                                null)),
+                                        null))
+                                .build()))
+                        .build())
+                .build();
+
+        assertModelEquals(expected, actual);
+    }
+
+    @Test
     void testBuildExtensions() throws Exception {
         Model actual = loadAndParse("build-extensions.yaml");
         Model expected = Model.newBuilder()

--- a/extension/src/test/resources/yaml/build-plugin-config-attributes-wrapper.yaml
+++ b/extension/src/test/resources/yaml/build-plugin-config-attributes-wrapper.yaml
@@ -1,0 +1,23 @@
+##
+## Copyright (c) 2025 Guillaume Nodet
+##
+## This program and the accompanying materials are made available under
+## the terms of the Eclipse Public License 2.0 which accompanies this
+## distribution and is available at:
+## https://www.eclipse.org/legal/epl-2.0/
+##
+## SPDX-License-Identifier: EPL-2.0
+##
+modelVersion: 4.0.0
+groupId: org.apache.maven.extensions
+artifactId: maven-yaml-extension
+version: 1.0.0-SNAPSHOT
+name: Maven YAML Extension
+build:
+  plugins:
+  - id: org.apache.maven.plugins:maven-shade-plugin:3.5.0
+    configuration:
+      transformers:
+        - transformer:
+            "@implementation": org.apache.maven.plugins.shade.resource.ManifestResourceTransformer
+            mainClass: com.example.Main


### PR DESCRIPTION
_Claude Code on behalf of Guillaume Nodet_

## Summary

- Add test coverage for the wrapper-object array form of `@attribute` handling in `buildXmlNode`
- The existing test from #52 only covered the regular-object path; this covers the wrapper-object path (where the first field matches the singular name of the parent array)

```yaml
# wrapper-object form (this test)
transformers:
  - transformer:
      "@implementation": ...
      mainClass: com.example.Main

# vs regular-object form (existing test)
transformers:
  - "@implementation": ...
    mainClass: com.example.Main
```

## Test plan

- [x] New `testBuildPluginConfigAttributesWrapper` test passes
- [x] All 78 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for parsing YAML that uses a wrapper around plugin transformer configuration.
  * Included a new sample YAML file to verify Maven plugin settings are read and matched correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->