### PR TITLE
Use Maven's standard coordinate order and document compact string syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,19 +218,19 @@ All parts are optional with Maven 4's inference mechanism (they can be inferred 
 
 ### Dependency Strings
 
-Dependencies support an extended syntax with type, classifier, scope, and optional marker:
+Dependencies use Maven's standard coordinate format, with version always last:
 
 ```
-groupId:artifactId[:version][:type][:classifier][@scope][?]
+groupId:artifactId[[:type[:classifier]]:version][@scope][?]
 ```
 
 | Element | Delimiter | Description |
 |---------|-----------|-------------|
 | `groupId` | first `:` segment | Maven group ID |
 | `artifactId` | second `:` segment | Maven artifact ID |
-| `version` | third `:` segment | Version (optional) |
-| `type` | fourth `:` segment | Packaging type, e.g. `jar`, `test-jar`, `pom` |
-| `classifier` | fifth `:` segment | Classifier, e.g. `tests`, `sources` |
+| `type` | third `:` segment (when 4+ parts) | Packaging type, e.g. `jar`, `test-jar`, `pom` |
+| `classifier` | fourth `:` segment (when 5 parts) | Classifier, e.g. `tests`, `sources` |
+| `version` | last `:` segment | Version (always last, optional) |
 | `@scope` | after `@` | Scope: `compile`, `provided`, `runtime`, `test`, `system`, `import` |
 | `?` | trailing suffix | Marks the dependency as optional |
 
@@ -238,12 +238,12 @@ groupId:artifactId[:version][:type][:classifier][@scope][?]
 
 | String | Description |
 |--------|-------------|
-| `org.apache.maven:maven-core:3.9.0` | Basic G:A:V |
+| `org.apache.maven:maven-core:3.9.0` | G:A:V |
 | `org.junit.jupiter:junit-jupiter-api@test` | G:A with scope (version inferred) |
 | `org.apache.maven:maven-api-spi:${maven.version}@provided` | G:A:V with scope |
-| `org.apache.maven:maven-model:3.9.0:jar` | G:A:V with type |
-| `org.apache.maven:maven-core:3.9.0:jar@provided` | G:A:V:type with scope |
-| `org.apache.maven:maven-core:3.9.0:test-jar:tests@test` | G:A:V:type:classifier with scope |
+| `org.apache.maven:maven-model:jar:3.9.0` | G:A:type:V |
+| `org.apache.maven:maven-core:jar:3.9.0@provided` | G:A:type:V with scope |
+| `org.apache.maven:maven-core:test-jar:tests:3.9.0@test` | G:A:type:classifier:V with scope |
 | `org.junit:junit-bom:5.12.0@import` | BOM import |
 | `commons-io:commons-io:2.11.0?` | Optional dependency |
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,106 @@ dependencies = [
         params = ["packageModelV4=org.apache.maven.api.model"]
 ```
 
+## Compact String Syntax
+
+Mason lets you write Maven coordinates as compact strings instead of verbose XML-style objects.
+
+### GAV Strings
+
+Used for `parent`, project `id`, plugins, and extensions:
+
+```
+groupId:artifactId[:version]
+```
+
+All parts are optional with Maven 4's inference mechanism (they can be inferred from parent or dependency management).
+
+| Example | Description |
+|---------|-------------|
+| `org.apache:apache:28` | Full G:A:V |
+| `org.apache.maven.plugins:maven-compiler-plugin` | G:A only (version inferred) |
+
+### Dependency Strings
+
+Dependencies support an extended syntax with type, classifier, scope, and optional marker:
+
+```
+groupId:artifactId[:version][:type][:classifier][@scope][?]
+```
+
+| Element | Delimiter | Description |
+|---------|-----------|-------------|
+| `groupId` | first `:` segment | Maven group ID |
+| `artifactId` | second `:` segment | Maven artifact ID |
+| `version` | third `:` segment | Version (optional) |
+| `type` | fourth `:` segment | Packaging type, e.g. `jar`, `test-jar`, `pom` |
+| `classifier` | fifth `:` segment | Classifier, e.g. `tests`, `sources` |
+| `@scope` | after `@` | Scope: `compile`, `provided`, `runtime`, `test`, `system`, `import` |
+| `?` | trailing suffix | Marks the dependency as optional |
+
+**Examples:**
+
+| String | Description |
+|--------|-------------|
+| `org.apache.maven:maven-core:3.9.0` | Basic G:A:V |
+| `org.junit.jupiter:junit-jupiter-api@test` | G:A with scope (version inferred) |
+| `org.apache.maven:maven-api-spi:${maven.version}@provided` | G:A:V with scope |
+| `org.apache.maven:maven-model:3.9.0:jar` | G:A:V with type |
+| `org.apache.maven:maven-core:3.9.0:jar@provided` | G:A:V:type with scope |
+| `org.apache.maven:maven-core:3.9.0:test-jar:tests@test` | G:A:V:type:classifier with scope |
+| `org.junit:junit-bom:5.12.0@import` | BOM import |
+| `commons-io:commons-io:2.11.0?` | Optional dependency |
+
+### The `id` Field
+
+Instead of a bare string, you can use the `id` field inside an object. This is useful when you need to specify additional properties alongside the compact coordinates:
+
+```yaml
+dependencies:
+  - id: org.apache.maven:maven-core:3.9.0@provided
+  - id: org.junit.jupiter:junit-jupiter-api@test
+    exclusions:
+      - org.junit.jupiter:junit-jupiter-engine
+
+parent:
+  id: org.apache:apache:28
+  relativePath: ../pom.xml
+
+build:
+  plugins:
+    - id: org.apache.maven.plugins:maven-compiler-plugin:3.11.0
+      configuration:
+        release: 17
+```
+
+### Direct String Values
+
+Any object that supports compact syntax can be written as a plain string. These are equivalent:
+
+```yaml
+# Compact string
+parent: org.apache:apache:28
+
+# Expanded object
+parent:
+  groupId: org.apache
+  artifactId: apache
+  version: "28"
+```
+
+```yaml
+# Compact string
+dependencies:
+  - org.apache.maven:maven-core:3.9.0@provided
+
+# Expanded object
+dependencies:
+  - groupId: org.apache.maven
+    artifactId: maven-core
+    version: 3.9.0
+    scope: provided
+```
+
 ## Building
 
 ```bash

--- a/extension/src/main/java/eu/maveniverse/maven/mason/JsonReaderHelper.java
+++ b/extension/src/main/java/eu/maveniverse/maven/mason/JsonReaderHelper.java
@@ -79,14 +79,16 @@ public class JsonReaderHelper {
     }
 
     /**
-     * Parses a GASVTCO (GroupId:ArtifactId[:Version][:Type][:Classifier][@Scope][?]) string.
+     * Parses a dependency coordinate string using Maven's standard format:
+     * {@code groupId:artifactId[[:type[:classifier]]:version][@scope][?]}
+     * <p>
      * With Maven 4's inference mechanism, groupId can be optional as it may be inferred
      * from dependency management or parent. ArtifactId is still required.
      * @return String array containing [groupId, artifactId, scope, version, type, classifier, optional]
      */
     public static String[] parseGasvtcoString(String str, JsonParser parser) throws IOException {
         if (str == null) {
-            throw new IOException("GASVTC string cannot be null at line "
+            throw new IOException("Dependency coordinate string cannot be null at line "
                     + parser.currentLocation().getLineNr() + ", column "
                     + parser.currentLocation().getColumnNr());
         }
@@ -111,22 +113,32 @@ public class JsonReaderHelper {
             return result;
         }
 
+        // Maven standard coordinate format: groupId:artifactId[[:type[:classifier]]:version]
+        //   2 parts: g:a
+        //   3 parts: g:a:v
+        //   4 parts: g:a:type:v
+        //   5 parts: g:a:type:classifier:v
         String[] parts = coords.split(":", -1); // -1 to keep trailing empty strings
         if (parts.length > 5) {
-            throw new IOException(
-                    "GASVTC string must have at most 5 parts (groupId:artifactId[:version][:type][:classifier]), found "
-                            + parts.length + " parts in '" + str + "' at line "
-                            + parser.currentLocation().getLineNr()
-                            + ", column " + parser.currentLocation().getColumnNr());
+            throw new IOException("Dependency coordinate string must have at most 5 parts"
+                    + " (groupId:artifactId[[:type[:classifier]]:version]), found "
+                    + parts.length + " parts in '" + str + "' at line "
+                    + parser.currentLocation().getLineNr()
+                    + ", column " + parser.currentLocation().getColumnNr());
         }
 
-        // With Maven 4 inference, groupId can be optional (inferred from dependencyManagement or parent)
-        // ArtifactId is typically still required for dependencies
         if (parts.length > 0) result[0] = parts[0].isEmpty() ? null : parts[0]; // groupId
         if (parts.length > 1) result[1] = parts[1].isEmpty() ? null : parts[1]; // artifactId
-        if (parts.length > 2) result[3] = parts[2].isEmpty() ? null : parts[2]; // version
-        if (parts.length > 3) result[4] = parts[3].isEmpty() ? null : parts[3]; // type
-        if (parts.length > 4) result[5] = parts[4].isEmpty() ? null : parts[4]; // classifier
+        if (parts.length == 3) {
+            result[3] = parts[2].isEmpty() ? null : parts[2]; // version
+        } else if (parts.length == 4) {
+            result[4] = parts[2].isEmpty() ? null : parts[2]; // type
+            result[3] = parts[3].isEmpty() ? null : parts[3]; // version
+        } else if (parts.length == 5) {
+            result[4] = parts[2].isEmpty() ? null : parts[2]; // type
+            result[5] = parts[3].isEmpty() ? null : parts[3]; // classifier
+            result[3] = parts[4].isEmpty() ? null : parts[4]; // version
+        }
 
         // Set scope and optional flag
         result[2] = scope; // scope

--- a/extension/src/test/java/eu/maveniverse/maven/mason/YamlParserTest.java
+++ b/extension/src/test/java/eu/maveniverse/maven/mason/YamlParserTest.java
@@ -416,14 +416,14 @@ class YamlParserTest {
                                 .scope("test")
                                 .version("5.9.3")
                                 .build(),
-                        // g:a:v:type
+                        // g:a:type:v
                         Dependency.newBuilder()
                                 .groupId("org.apache.maven")
                                 .artifactId("maven-model")
                                 .version("3.9.0")
                                 .type("jar")
                                 .build(),
-                        // g:a:scope:v:type
+                        // g:a:type:v@scope
                         Dependency.newBuilder()
                                 .groupId("org.apache.maven")
                                 .artifactId("maven-core")
@@ -431,7 +431,7 @@ class YamlParserTest {
                                 .version("3.9.0")
                                 .type("jar")
                                 .build(),
-                        // g:a:scope:v:type:classifier
+                        // g:a:type:classifier:v@scope
                         Dependency.newBuilder()
                                 .groupId("org.apache.maven")
                                 .artifactId("maven-core")

--- a/extension/src/test/resources/yaml/dependency-gav.yaml
+++ b/extension/src/test/resources/yaml/dependency-gav.yaml
@@ -14,9 +14,9 @@ dependencies:
   - org.apache.maven:maven-core:3.9.0
   # g:a:v@scope
   - org.junit.jupiter:junit-jupiter:5.9.3@test
-  # g:a:v:type
-  - org.apache.maven:maven-model:3.9.0:jar
-  # g:a:v:type@scope
-  - org.apache.maven:maven-core:3.9.0:jar@provided
-  # g:a:v:type:classifier@scope
-  - org.apache.maven:maven-core:3.9.0:test-jar:tests@test
+  # g:a:type:v
+  - org.apache.maven:maven-model:jar:3.9.0
+  # g:a:type:v@scope
+  - org.apache.maven:maven-core:jar:3.9.0@provided
+  # g:a:type:classifier:v@scope
+  - org.apache.maven:maven-core:test-jar:tests:3.9.0@test


### PR DESCRIPTION
## Summary

- **Breaking change:** Fix dependency coordinate parsing to use Maven's standard format where version comes last: `g:a[:type[:classifier]]:version` instead of the previous `g:a:version:type:classifier`. This only affects dependencies that specify type or classifier — the common `g:a:v` and `g:a:v@scope` forms are unchanged.
- Add a "Compact String Syntax" section to the README documenting all shorthand formats: GAV strings, dependency strings, the `id` field, and direct string values

## Test plan

- [x] All 77 existing tests pass
- [x] Updated `dependency-gav.yaml` test fixtures to use the corrected coordinate order
- [x] Cross-checked parsing logic against Maven's standard format

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)